### PR TITLE
Scope VERSION constant within SlopeOne namespace.

### DIFF
--- a/lib/slope_one.rb
+++ b/lib/slope_one.rb
@@ -1,5 +1,3 @@
-VERSION = '0.1.1'
-
 class SlopeOne
   attr_accessor :diffs, :freqs
   

--- a/lib/slope_one/version.rb
+++ b/lib/slope_one/version.rb
@@ -1,0 +1,3 @@
+class SlopeOne
+  VERSION = '0.1.1'
+end

--- a/slope_one.gemspec
+++ b/slope_one.gemspec
@@ -1,6 +1,9 @@
+$:.push File.expand_path("../lib", __FILE__)
+require 'slope_one/version'
+
 Gem::Specification.new do |s|
   s.name        = "slope_one"
-  s.version     = '0.1.1'
+  s.version     = SlopeOne::VERSION
   s.authors     = ["Ashley Williams"]
   s.email       = ["hi@ashleyw.co.uk"]
   s.homepage    = "http://github.com/ashleyw/Slope-One"


### PR DESCRIPTION
Currently, `VERSION` is defined in the global namespace. It can collide with another global `VERSION` constant causing a constant redefinition warning. This commit moves it within the `SlopeOne` namespace to avoid this problem.

The pattern here (`lib/scope/version.rb`) is a common one. It's used, e.g., when you use bundler's gem skeleton generator.

One of the benefits of having the version constant in a separate file, is that it is possible to source the version in the gemspec without a chicken-egg problem. This branch makes that change also.
